### PR TITLE
Fixed "EOS.undent" deprecation

### DIFF
--- a/elasticsearch17.rb
+++ b/elasticsearch17.rb
@@ -64,7 +64,7 @@ class Elasticsearch17 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -74,7 +74,7 @@ class Elasticsearch17 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch17/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">


### PR DESCRIPTION
Changed `<<-EOS.undent` to `<<~EOS` to fix a deprecation error, resolving #2 